### PR TITLE
Publish documentation to GitHub Pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+Changelog
+---------
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+Checklist
+---------
+
+- [ ] Test
+- [ ] Self-review
+- [ ] Documentation

--- a/.github/workflows/add_issue_to_triage_board.yml
+++ b/.github/workflows/add_issue_to_triage_board.yml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
   pull_request_target:
+    branches:
+      - main
     types:
       - opened
 jobs:

--- a/.github/workflows/doc-ci-cd.yml
+++ b/.github/workflows/doc-ci-cd.yml
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 ---
-name: Documentation Release
+name: Documentation CI/CD
 
 'on':
   pull_request:
@@ -12,8 +12,8 @@ name: Documentation Release
       - master
 
 jobs:
-  deploy-documentation:
-    name: Deploy Documentation to GitHub Pages
+  documentation-ci-cd:
+    name: Test & Release Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
       - name: Build documentation
         run: npm run build
       - name: Deploy to GitHub Pages
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/doc-ci-cd.yml
+++ b/.github/workflows/doc-ci-cd.yml
@@ -14,7 +14,6 @@ name: Documentation Release
 jobs:
   deploy-documentation:
     name: Deploy Documentation to GitHub Pages
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/doc-ci-cd.yml
+++ b/.github/workflows/doc-ci-cd.yml
@@ -6,6 +6,7 @@
 name: Documentation Release
 
 'on':
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/doc-ci-cd.yml
+++ b/.github/workflows/doc-ci-cd.yml
@@ -1,0 +1,34 @@
+# Copyright (c) Jiaqi Liu.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+---
+name: Documentation Release
+
+'on':
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-documentation:
+    name: Deploy Documentation to GitHub Pages
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm install
+      - name: Build documentation
+        run: npm run build
+      - name: Deploy to GitHub Pages
+        # if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          user_name: QubitPi
+          user_email: jack20220723@gmail.com

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ cypress/videos
 themes
 .eslintcache
 db.json
+
+.idea/

--- a/docs/guides/core-concepts/testing-types.mdx
+++ b/docs/guides/core-concepts/testing-types.mdx
@@ -37,9 +37,7 @@ a real browser, visiting URLs, viewing content, clicking on links and buttons,
 etc. Testing this way helps ensure your tests and the user's experience are the
 same.
 
-Writing end-to-end tests in Cypress can be done by developers building the
-application, specialized testing engineers, or a quality assurance team
-responsible for verifying an app is ready for release. Tests are written in code
+Writing end-to-end tests in Cypress is done by developers. Tests are written in code
 with an API that simulates the steps that a real user would take.
 
 End-to-end tests are great at verifying your app runs as intended, from the
@@ -55,7 +53,6 @@ on how to handle this complexity.
 
 - Ensure your app is functioning as a cohesive whole
 - Tests match the user experience
-- Can be written by developers or QA Teams
 - Can be used for integration testing as well
 
 :::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,8 +17,10 @@ const config = {
   title: 'Cypress Documentation',
   tagline:
     'Fast, easy and reliable testing for anything that runs in a browser.',
-  url: 'https://docs.cypress.io',
-  baseUrl: '/',
+  url: 'https://QubitPi.github.io/',
+  baseUrl: '/cypress-documentation/',
+  organizationName: 'QubitPi',
+  projectName: 'cypress-documentation',
   onBrokenLinks: 'throw', // TODO: update this to throw when we go live to production
   onBrokenMarkdownLinks: 'throw',
   favicon: undefined,


### PR DESCRIPTION
Changelog
---------

### Added

- Added documentation CI/CD

  - Each PR triggers documentation test build
  - Each commit to `master` branch (through PR for example) triggers the test above and, if test pass, automatically deploys documentation to GitHub Pages

- Added PR template
- Add Docusaurus base path config so that the doc displays properly on GitHub Pages
- Untriggered remote project management of Cypress team

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
