### PR TITLE
Add documentation on how to make dblclick work

### DIFF
--- a/docs/api/actions/dblclick.mdx
+++ b/docs/api/actions/dblclick.mdx
@@ -189,6 +189,18 @@ cy.get('li:first').dblclick({
 `.dblclick()` is an "action command" that follows all the rules of
 [Actionability](/guides/core-concepts/interacting-with-elements).
 
+## Troubleshooting
+
+### Cypress's dblclick does not function the same way as a user double clicking
+
+We can issue a click command followed by the dblclick to workaround this. For example:
+
+```js
+cy.get('[data-testid="my-svg"]')
+  .trigger('click', 200, 200, { force: true })
+  .trigger('dblclick', 200, 200, { force: true })
+```
+
 ## Rules
 
 ### Requirements [<Icon name="question-circle"/>](/guides/core-concepts/introduction-to-cypress#Chains-of-Commands) {#Requirements}


### PR DESCRIPTION
Reference
---------

- [**Cypress's dblclick does not function the same way as a user double clicking**](https://github.com/cypress-io/cypress/issues/3224#issuecomment-526580265)
